### PR TITLE
lib, tests: implement std::error::Error for OsReleaseError

### DIFF
--- a/tests/test_os_release.rs
+++ b/tests/test_os_release.rs
@@ -5,7 +5,10 @@ use rs_release::{OsReleaseError, parse_os_release, parse_os_release_str};
 #[test]
 fn fails_on_io_errors() {
     for file in &["", "/etc/non_existing_file", "/etc/shadow"] {
-        assert_eq!(Err(OsReleaseError::Io), parse_os_release(file));
+        match parse_os_release(file) {
+            Err(OsReleaseError::Io(_)) => {}
+            err => panic!("Expected OsReleaseError::Io, but instead got {:?}", err),
+        }
     }
 }
 


### PR DESCRIPTION
Hi! `OsReleaseError` currently doesn't implement `std::error::Error`, which makes it slightly more difficult to use with the [error-chain](https://crates.io/crates/error-chain) crate. I've implemented this in this pull request, as well as changing `OsReleaseError::Io` to wrap the  corresponding`std::io::Error`. 

Let me know if you think any additional changes are needed in order to merge this!