### PR TITLE
Use snailquote crate to unescape values

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ keywords = ["os-release", "env", "systemd"]
 license = "MIT/Apache-2.0"
 
 [dependencies]
+snailquote = "0.1"

--- a/tests/data/os-release-escaped-three-env
+++ b/tests/data/os-release-escaped-three-env
@@ -1,0 +1,3 @@
+NAME="Multi-line\n\"Linux\""
+VERSION='0.1\n-same-line'
+WEIRD_QUOTES='To escape \t' "use double-quotes: \t"

--- a/tests/test_os_release.rs
+++ b/tests/test_os_release.rs
@@ -41,6 +41,21 @@ fn trims_quotes() {
 }
 
 #[test]
+fn unescapes_characters() {
+    let path = "tests/data/os-release-escaped-three-env";
+    let os_release = parse_os_release(path);
+    assert!(os_release.is_ok());
+    let os_release = os_release.unwrap();
+    assert_eq!(3, os_release.len());
+    assert_eq!("Multi-line\n\"Linux\"", os_release["NAME"]);
+    assert_eq!(r#"0.1\n-same-line"#, os_release["VERSION"]);
+    assert_eq!(
+        "To escape \\t use double-quotes: \t",
+        os_release["WEIRD_QUOTES"]
+    );
+}
+
+#[test]
 fn ignores_comments() {
     let path = "tests/data/os-release-comment";
     let os_release = parse_os_release(path);


### PR DESCRIPTION
Removes requirement for manual trimming and supports more types of values.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jightuse/rs-release/2)
<!-- Reviewable:end -->
